### PR TITLE
add culture module stacking

### DIFF
--- a/d20_governance/bot.py
+++ b/d20_governance/bot.py
@@ -106,6 +106,7 @@ class JoinLeaveView(discord.ui.View):
             )
 
 
+# EVENTS
 @bot.event
 async def on_ready():
     """
@@ -125,6 +126,22 @@ async def on_guild_join(guild):
     """
     print(f"D20 Bot has been invited to server `{guild.name}`")
     await setup_server(guild)
+
+
+@bot.event
+async def on_reaction_add(reaction, user):
+    if user.bot:
+        return
+
+    if hasattr(bot, "vote_message") and reaction.message.id == bot.vote_message.id:
+        if user.id in bot.voters:
+            await reaction.remove(user)
+            await user.send(
+                f"Naughty naughty! You cannot vote twice!",
+                delete_after=VOTE_DURATION_SECONDS,
+            )
+        else:
+            bot.voters.add(user.id)
 
 
 # QUEST START AND PROGRESSION
@@ -410,8 +427,6 @@ async def end(ctx):
 
 
 # CULTURE COMMANDS
-
-
 @bot.command()
 @commands.check(lambda ctx: ctx.channel.name == "d20-agora")
 async def transparency(ctx):
@@ -475,7 +490,26 @@ async def obscurity(ctx, mode: str = None):
             color=discord.Color.dark_gold(),
         )
         if OBSCURITY:
-            embed.add_field(name="Mode:", value=f"{OBSCURITY_MODE}", inline=False)
+            if "OBSCURITY" not in active_culture_modes:
+                active_culture_modes.append("OBSCURITY")
+                embed.add_field(
+                    name="Mode:",
+                    value=f"{OBSCURITY_MODE}",
+                    inline=False,
+                )
+                embed.add_field(
+                    name="ACTIVE CULTURE MODES:",
+                    value=f"{', '.join(active_culture_modes)}",
+                    inline=False,
+                )
+            else:
+                if "OBSCURITY" in active_culture_modes:
+                    active_culture_modes.remove("OBSCURITY")
+                    embed.add_field(
+                        name="ACTIVE CULTURE MODES:",
+                        value=f"{', '.join(active_culture_modes)}",
+                        inline=False,
+                    )
     elif mode not in available_modes:
         embed = discord.Embed(
             title=f"Error - The mode '{mode}' is not available.",
@@ -488,6 +522,13 @@ async def obscurity(ctx, mode: str = None):
             title="Culture: Obscurity On!", color=discord.Color.dark_gold()
         )
         embed.add_field(name="Mode:", value=f"{OBSCURITY_MODE}", inline=False)
+        if "OBSCURITY" not in active_culture_modes:
+            active_culture_modes.append("OBSCURITY")
+        embed.add_field(
+            name="ACTIVE CULTURE MODES:",
+            value=f"{', '.join(active_culture_modes)}",
+            inline=False,
+        )
 
     embed.set_thumbnail(
         url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/obscurity.png"
@@ -502,24 +543,32 @@ async def eloquence(ctx):
     global ELOQUENCE
     ELOQUENCE = not ELOQUENCE
     if ELOQUENCE:
-        embed = discord.Embed(
-            title="Culture: Eloquence", color=discord.Color.dark_gold()
-        )
-        embed.set_thumbnail(
-            url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/eloquence.png"
-        )
-        embed.add_field(
-            name="ACTIVATED:",
-            value="Messages will now be process through an LLM.",
-            inline=False,
-        )
-        embed.add_field(
-            name="LLM Prompt:",
-            value="You are from the Shakespearean era. Please rewrite the following text in a way that makes the speaker sound as eloquent, persuasive, and rhetorical as possible, while maintaining the original meaning and intent: [your message]",
-            inline=False,
-        )
-        await ctx.send(embed=embed)
+        if "ELOQUENCE" not in active_culture_modes:
+            active_culture_modes.append("ELOQUENCE")
+            embed = discord.Embed(
+                title="Culture: Eloquence", color=discord.Color.dark_gold()
+            )
+            embed.set_thumbnail(
+                url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/eloquence.png"
+            )
+            embed.add_field(
+                name="ACTIVATED:",
+                value="Messages will now be process through an LLM.",
+                inline=False,
+            )
+            embed.add_field(
+                name="ACTIVE CULTURE MODES:",
+                value=f"{', '.join(active_culture_modes)}",
+                inline=False,
+            )
+            embed.add_field(
+                name="LLM Prompt:",
+                value="You are from the Shakespearean era. Please rewrite the following text in a way that makes the speaker sound as eloquent, persuasive, and rhetorical as possible, while maintaining the original meaning and intent: [your message]",
+                inline=False,
+            )
+            await ctx.send(embed=embed)
     else:
+        active_culture_modes.remove("ELOQUENCE")
         embed = discord.Embed(
             title="Culture: Eloquence", color=discord.Color.dark_gold()
         )
@@ -529,6 +578,11 @@ async def eloquence(ctx):
         embed.add_field(
             name="DEACTIVATED",
             value="Messages will no longer be processed through an LLM",
+            inline=False,
+        )
+        embed.add_field(
+            name="ACTIVE CULTURE MODES:",
+            value=f"{', '.join(active_culture_modes)}",
             inline=False,
         )
         await ctx.send(embed=embed)
@@ -551,22 +605,58 @@ async def diversity(ctx):
     await ctx.send(message)
 
 
-@bot.event
-async def on_reaction_add(reaction, user):
-    if user.bot:
-        return
-
-    if hasattr(bot, "vote_message") and reaction.message.id == bot.vote_message.id:
-        if user.id in bot.voters:
-            await reaction.remove(user)
-            await user.send(
-                f"Naughty naughty! You cannot vote twice!",
-                delete_after=VOTE_DURATION_SECONDS,
+@bot.command()
+@commands.check(lambda ctx: ctx.channel.name == "d20-agora")
+async def ritual(ctx):
+    """
+    Toggle ritual module.
+    """
+    global RITUAL
+    RITUAL = not RITUAL
+    if RITUAL:
+        if "RITUAL" not in active_culture_modes:
+            active_culture_modes.append("RITUAL")
+            embed = discord.Embed(
+                title="Culture: ritual", color=discord.Color.dark_gold()
             )
-        else:
-            bot.voters.add(user.id)
+            # embed.set_thumbnail(
+            #     url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/ritual.png"
+            # )
+            embed.add_field(
+                name="ACTIVATED:",
+                value="A ritual of agreement permeates throughout the group.",
+                inline=False,
+            )
+            embed.add_field(
+                name="ACTIVE CULTURE MODES:",
+                value=f"{', '.join(active_culture_modes)}",
+                inline=False,
+            )
+            await ctx.send(embed=embed)
+    else:
+        active_culture_modes.remove("RITUAL")
+        embed = discord.Embed(title="Culture: ritual", color=discord.Color.dark_gold())
+        # embed.set_thumbnail(
+        #     url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/ritual.png"
+        # )
+        embed.add_field(
+            name="DEACTIVATED",
+            value="Automatic agreement has ended. But will the effects linger in practice?",
+            inline=False,
+        )
+        embed.add_field(
+            name="ACTIVE CULTURE MODES:",
+            value=f"{', '.join(active_culture_modes)}",
+            inline=False,
+        )
+        await ctx.send(embed=embed)
 
 
+# CULTURE MODES
+active_culture_modes = []
+
+
+# DECISION COMMANDS
 @bot.command()
 @commands.check(lambda ctx: ctx.channel.name == "d20-agora")
 async def vote(ctx, question: str, *options: str):
@@ -817,49 +907,6 @@ async def test_decision(ctx):
     await vote_governance(ctx, "decision")
 
 
-@bot.command()
-@commands.check(lambda ctx: ctx.channel.name == "d20-agora")
-async def ritual(ctx):
-    """
-    Toggle ritual module.
-    """
-    global RITUAL
-    RITUAL = not RITUAL
-    if RITUAL:
-        embed = discord.Embed(title="Culture: ritual", color=discord.Color.dark_gold())
-        # embed.set_thumbnail(
-        #     url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/ritual.png"
-        # )
-        embed.add_field(
-            name="ACTIVATED:",
-            value="A ritual of agreement permeates throughout the group.",
-            inline=False,
-        )
-        await ctx.send(embed=embed)
-    else:
-        embed = discord.Embed(title="Culture: ritual", color=discord.Color.dark_gold())
-        # embed.set_thumbnail(
-        #     url="https://raw.githubusercontent.com/metagov/d20-governance/main/assets/imgs/embed_thumbnails/ritual.png"
-        # )
-        embed.add_field(
-            name="DEACTIVATED",
-            value="Automatic agreement has ended. But will the effects linger in practice?",
-            inline=False,
-        )
-        await ctx.send(embed=embed)
-
-
-def ritual_function(previous_message, new_message):
-    llm = OpenAI(temperature=0.9)
-    prompt = PromptTemplate(
-        input_variables=["previous_message", "new_message"],
-        template="Write a message that reflects the content in {new_message} and is cast in agreement with {previous_message}",
-    )
-    chain = LLMChain(llm=llm, prompt=prompt)
-    response = chain.run(previous_message=previous_message, new_message=new_message)
-    return response
-
-
 # ON MESSAGE
 @bot.event
 async def on_message(message):
@@ -878,43 +925,52 @@ async def on_message(message):
             user_message_count[user_id] = 0
         user_message_count[user_id] += 1
 
-        # Get the most recently posted message in the channel that isn't from a bot
-        async for msg in message.channel.history(limit=100):
-            if msg.id == message.id:
-                continue
-            if msg.author.bot:
-                continue
-            if msg.content.startswith("/"):
-                continue
-            previous_message = msg.content
-            break
+        # Check if any modes are active and apply filters in list order
+        filtered_message = message.content
+        if active_culture_modes:
+            await message.delete()
+            bot_message = await message.channel.send(
+                f"{message.author.mention} posted: {filtered_message}"
+            )
+        for mode in active_culture_modes:
+            if mode == "RITUAL":
+                # Get the most recently posted message in the channel that isn't from a bot
+                async for msg in message.channel.history(limit=100):
+                    if msg.id == message.id:
+                        continue
+                    if msg.author.bot:
+                        continue
+                    if msg.content.startswith("/"):
+                        continue
+                    previous_message = msg.content
+                    break
 
-        if RITUAL:
-            await message.delete()
-            processing_message = await message.channel.send(
-                f"Bringing {message.author.mention}'s message:\n`{message.content}`\n\n into alignment with {msg.author.mention}'s previous message:\n`{msg.content}`"
-            )
-            response = ritual_function(msg.content, message.content)
-            # await processing_message.delete()
-            await message.channel.send(f"{message.author.mention} posted: {response}")
+                processing_message = await message.channel.send(
+                    f"Bringing {message.author.mention}'s message:\n`{filtered_message}`\n\n into alignment with {msg.author.mention}'s previous message:\n`{previous_message}`"
+                )
+                filtered_message = initialize_ritual_agreement(
+                    previous_message, filtered_message
+                )
+                await processing_message.delete()
+                await bot_message.edit(
+                    content=f"{message.author.mention}'s post has passed through a culture of {mode.lower()}: {filtered_message}"
+                )
+            if mode == "OBSCURITY":
+                obscurity_function = globals()[OBSCURITY_MODE]
+                filtered_message = obscurity_function(filtered_message)
+                await bot_message.edit(
+                    content=f"{message.author.mention}'s post has passed through a culture of {mode.lower()}: {filtered_message}"
+                )
+            if mode == "ELOQUENCE":
+                processing_message = await message.channel.send(
+                    f"Making {message.author.mention}'s post eloquent"
+                )
+                filtered_message = await filter_eloquence(filtered_message)
+                await processing_message.delete()
+                await bot_message.edit(
+                    content=f"{message.author.mention}'s post has passed through a culture of {mode.lower()}: {filtered_message}"
+                )
 
-        elif OBSCURITY:
-            await message.delete()
-            obscurity_function = globals()[OBSCURITY_MODE]
-            obscured_message = obscurity_function(message.content)
-            await message.channel.send(
-                f"{message.author.mention} posted: {obscured_message}"
-            )
-        elif ELOQUENCE:
-            await message.delete()
-            processing_message = await message.channel.send(
-                f"Making {message.author.mention}'s post eloquent"
-            )
-            eloquent_text = await filter_eloquence(message.content)
-            await processing_message.delete()
-            await message.channel.send(
-                f"{message.author.mention} posted: {eloquent_text}"
-            )
     except Exception as e:
         print(f"An error occurred: {e}")
         await message.channel.send("An error occurred")

--- a/d20_governance/utils/cultures.py
+++ b/d20_governance/utils/cultures.py
@@ -75,3 +75,14 @@ async def send_msg_to_random_player():
     await dm_channel.send(
         "🌟 Greetings, esteemed adventurer! A mischievous gnome has entrusted me with a cryptic message just for you: 'In the land of swirling colors, where unicorns prance and dragons snooze, a hidden treasure awaits those who dare to yawn beneath the crescent moon.' Keep this message close to your heart and let it guide you on your journey through the wondrous realms of the unknown. Farewell, and may your path be ever sprinkled with stardust! ✨"
     )
+
+
+def initialize_ritual_agreement(previous_message, new_message):
+    llm = OpenAI(temperature=0.9)
+    prompt = PromptTemplate(
+        input_variables=["previous_message", "new_message"],
+        template="Write a message that reflects the content in {new_message} and is cast in agreement with {previous_message}. Preserve and transfer any spelling errors or text transformations in these messages in the response.",
+    )  # FIXME: This template does not preserve obscurity text processing. Maybe obscurity should be reaplied after ritual if active in the active_culture_mode list
+    chain = LLMChain(llm=llm, prompt=prompt)
+    response = chain.run(previous_message=previous_message, new_message=new_message)
+    return response


### PR DESCRIPTION
add a way of tracking culture module activations and processing messages in the order the culture modules were activated in. 

the obscurity function still needs some work to remove "OBSCURITY" from the active_culture_modes list when deactivated. could you take a look at that function @blue-note? 